### PR TITLE
Add SVG support

### DIFF
--- a/classes/eml/Controller/class-external-files.php
+++ b/classes/eml/Controller/class-external-files.php
@@ -435,6 +435,10 @@ class External_Files {
 					'label' => __( 'WEBP', 'external-files-in-media-library' ),
 					'ext'   => 'webp',
 				),
+				'image/svg+xml'   => array(
+					'label' => __( 'SVG', 'external-files-in-media-library' ),
+					'ext'   => 'svg',
+				),
 				'application/pdf' => array(
 					'label' => __( 'PDF', 'external-files-in-media-library' ),
 					'ext'   => 'pdf',


### PR DESCRIPTION
Hello Thomas,

I use your plugin to store the images in a central media site in a WordPress multisite installation. It doesn't feel right to upload the same images to each site over and over again.

Since I missed support for SVG files, I customized the code accordingly. Only 4 lines seem to be necessary. Your code is well thought out.

Thanks for sharing your work. You have saved me from writing my own plugin or using less elegant solutions.

Greetings, Christian